### PR TITLE
add oauth-client module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ stages:
 before_install:
   - sudo apt-get update
   - env | grep TRAVIS
-  - pyenv global 3.8
 
 jobs:
   include:

--- a/modules/oauth-client/.gitignore
+++ b/modules/oauth-client/.gitignore
@@ -1,0 +1,4 @@
+target/
+*.iml
+
+oauth-client/

--- a/modules/oauth-client/README.md
+++ b/modules/oauth-client/README.md
@@ -1,4 +1,4 @@
-# eventstreams-samples/java-apache/oauth-client
+# eventstreams-java-sdk/oauth-client
 
 This directory contains a supporting library when Java client is configuring SASL OAUTHBEARER as the authentication method and wants to obtain token from IBM Cloud IAM service via an IAM API key.
 
@@ -16,7 +16,7 @@ adding below in `pom.xml`'s dependencies
 <dependency>
     <groupId>com.ibm.cloud</groupId>
     <artifactId>eventstreams_sdk-oauth-client</artifactId>
-    <version>0.1.2</version>
+    <version>1.3.0</version>
 </dependency>
 ```
 
@@ -25,5 +25,5 @@ adding below in `pom.xml`'s dependencies
 adding below in `build.gradle`'s dependencies
 
 ```gradle
-implementation com.ibm.eventstreams:oauth-client:0.1.2
+implementation com.ibm.cloud.eventstreams_sdk-oauth-client:1.3.0
 ```

--- a/modules/oauth-client/README.md
+++ b/modules/oauth-client/README.md
@@ -1,0 +1,29 @@
+# eventstreams-samples/java-apache/oauth-client
+
+This directory contains a supporting library when Java client is configuring SASL OAUTHBEARER as the authentication method and wants to obtain token from IBM Cloud IAM service via an IAM API key.
+
+### Build locally
+
+```sh
+mvn clean package
+```
+
+### Build through Maven in client application
+
+adding below in `pom.xml`'s dependencies
+
+```xml
+<dependency>
+    <groupId>com.ibm.cloud</groupId>
+    <artifactId>eventstreams_sdk-oauth-client</artifactId>
+    <version>0.1.2</version>
+</dependency>
+```
+
+### Build through Gradle in client application
+
+adding below in `build.gradle`'s dependencies
+
+```gradle
+implementation com.ibm.eventstreams:oauth-client:0.1.2
+```

--- a/modules/oauth-client/pom.xml
+++ b/modules/oauth-client/pom.xml
@@ -71,20 +71,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/modules/oauth-client/pom.xml
+++ b/modules/oauth-client/pom.xml
@@ -1,0 +1,100 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>eventstreams-sdk</artifactId>
+        <groupId>com.ibm.cloud</groupId>
+        <version>1.3.0</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>eventstreams_sdk-oauth-client</artifactId>
+        <name>IBM Cloud Event Streams Java SDK</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>3.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>0.9.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.14.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/oauth-client/src/main/java/com/ibm/eventstreams_sdk/oauth/client/IAMAPIKeyTokenRetriever.java
+++ b/modules/oauth-client/src/main/java/com/ibm/eventstreams_sdk/oauth/client/IAMAPIKeyTokenRetriever.java
@@ -1,0 +1,45 @@
+// Copyright 2023 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.ibm.eventstreams_sdk.oauth.client;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenRetriever;
+
+public class IAMAPIKeyTokenRetriever extends IAMTokenRetriever implements AccessTokenRetriever {
+
+    public IAMAPIKeyTokenRetriever(String grantType, String apikey, String tokenEndpointUrl,
+                                   SSLSocketFactory sslSocketFactory, long loginRetryBackoffMs, long loginRetryBackoffMaxMs,
+                                   Integer loginConnectTimeoutMs, Integer loginReadTimeoutMs) {
+        this.grantExtensions = new HashMap<String, String>();
+        grantExtensions.put(IAMTokenRetrieverFactory.GRANT_TYPE_CONFIG, grantType);
+        grantExtensions.put(IAMTokenRetrieverFactory.GRANT_EXT_APIKEY, apikey);
+
+        this.tokenEndpointUrl = tokenEndpointUrl;
+        this.sslSocketFactory = sslSocketFactory;
+        this.loginRetryBackoffMs = loginRetryBackoffMs;
+        this.loginRetryBackoffMaxMs = loginRetryBackoffMaxMs;
+        this.loginConnectTimeoutMs = loginConnectTimeoutMs;
+        this.loginReadTimeoutMs = loginReadTimeoutMs;
+    }
+
+    @Override
+    public String retrieve() throws IOException {
+        return super.retrieve();
+    }
+}

--- a/modules/oauth-client/src/main/java/com/ibm/eventstreams_sdk/oauth/client/IAMOAuthBearerLoginCallbackHandler.java
+++ b/modules/oauth-client/src/main/java/com/ibm/eventstreams_sdk/oauth/client/IAMOAuthBearerLoginCallbackHandler.java
@@ -1,0 +1,115 @@
+// Copyright 2023 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.ibm.eventstreams_sdk.oauth.client;
+
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenRetriever;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenValidator;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenValidatorFactory;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class IAMOAuthBearerLoginCallbackHandler implements AuthenticateCallbackHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(IAMOAuthBearerLoginCallbackHandler.class);
+
+    private Map<String, Object> moduleOptions;
+
+    private AccessTokenRetriever accessTokenRetriever;
+
+    private AccessTokenValidator accessTokenValidator;
+
+    private boolean isInitialized = false;
+
+    @Override
+    public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+        moduleOptions = JaasOptionsUtils.getOptions(saslMechanism, jaasConfigEntries);
+        AccessTokenRetriever accessTokenRetriever = IAMTokenRetrieverFactory.create(configs, saslMechanism, moduleOptions);
+        AccessTokenValidator accessTokenValidator = AccessTokenValidatorFactory.create(configs, saslMechanism);
+        init(accessTokenRetriever, accessTokenValidator);
+    }
+
+    void init(AccessTokenRetriever accessTokenRetriever, AccessTokenValidator accessTokenValidator) {
+        this.accessTokenRetriever = accessTokenRetriever;
+        this.accessTokenValidator = accessTokenValidator;
+
+        try {
+            this.accessTokenRetriever.init();
+        } catch (IOException e) {
+            throw new KafkaException("The OAuth login configuration encountered an error when initializing the AccessTokenRetriever", e);
+        }
+
+        isInitialized = true;
+    }
+
+    @Override
+    public void close() {
+        if (accessTokenRetriever != null) {
+            try {
+                this.accessTokenRetriever.close();
+            } catch (IOException e) {
+                logger.warn("The OAuth login configuration encountered an error when closing the AccessTokenRetriever", e);
+            }
+        }
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        checkInitialized();
+
+        for (Callback callback : callbacks) {
+            if (callback instanceof OAuthBearerTokenCallback) {
+                handleTokenCallback((OAuthBearerTokenCallback) callback);
+            } else {
+                throw new UnsupportedCallbackException(callback);
+            }
+        }
+    }
+
+    private void handleTokenCallback(OAuthBearerTokenCallback callback) throws IOException {
+        checkInitialized();
+        String accessToken = accessTokenRetriever.retrieve();
+
+        try {
+            OAuthBearerToken token = accessTokenValidator.validate(accessToken);
+            callback.token(token);
+        } catch (ValidateException e) {
+            logger.warn(e.getMessage(), e);
+            callback.error("invalid_token", e.getMessage(), null);
+        }
+    }
+
+
+    private void checkInitialized() {
+        if (!isInitialized)
+            throw new IllegalStateException(String.format("To use %s, first call the configure or init method", getClass().getSimpleName()));
+    }
+
+}

--- a/modules/oauth-client/src/main/java/com/ibm/eventstreams_sdk/oauth/client/IAMTokenRetriever.java
+++ b/modules/oauth-client/src/main/java/com/ibm/eventstreams_sdk/oauth/client/IAMTokenRetriever.java
@@ -1,0 +1,273 @@
+// Copyright 2023 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.ibm.eventstreams_sdk.oauth.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.Retry;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.UnretryableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public abstract class IAMTokenRetriever {
+
+    private static final Logger log = LoggerFactory.getLogger(IAMTokenRetriever.class);
+
+    private static final Set<Integer> UNRETRYABLE_HTTP_CODES;
+
+    private static final int MAX_RESPONSE_BODY_LENGTH = 1000;
+
+    static {
+        // This does not have to be an exhaustive list. There are other HTTP codes that
+        // are defined in different RFCs (e.g.
+        // https://datatracker.ietf.org/doc/html/rfc6585)
+        // that we won't worry about yet. The worst case if a status code is missing
+        // from
+        // this set is that the request will be retried.
+        UNRETRYABLE_HTTP_CODES = new HashSet<>();
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_BAD_REQUEST);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_UNAUTHORIZED);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_PAYMENT_REQUIRED);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_FORBIDDEN);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_NOT_FOUND);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_BAD_METHOD);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_NOT_ACCEPTABLE);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_PROXY_AUTH);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_CONFLICT);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_GONE);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_LENGTH_REQUIRED);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_PRECON_FAILED);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_ENTITY_TOO_LARGE);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_REQ_TOO_LONG);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_UNSUPPORTED_TYPE);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+        UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_VERSION);
+    }
+
+    protected Map<String, String> grantExtensions;
+
+    protected SSLSocketFactory sslSocketFactory;
+
+    protected String tokenEndpointUrl;
+
+    protected long loginRetryBackoffMs;
+
+    protected long loginRetryBackoffMaxMs;
+
+    protected Integer loginConnectTimeoutMs;
+
+    protected Integer loginReadTimeoutMs;
+
+    protected String retrieve() throws IOException {
+        String requestBody = formatRequestBody(grantExtensions);
+        Retry<String> retry = new Retry<>(loginRetryBackoffMs, loginRetryBackoffMaxMs);
+
+        String responseBody;
+
+        try {
+            responseBody = retry.execute(() -> {
+                HttpURLConnection con = null;
+
+                try {
+                    con = (HttpURLConnection) new URL(tokenEndpointUrl).openConnection();
+
+                    if (sslSocketFactory != null && con instanceof HttpsURLConnection)
+                        ((HttpsURLConnection) con).setSSLSocketFactory(sslSocketFactory);
+
+                    return post(con, Collections.emptyMap(), requestBody, loginConnectTimeoutMs, loginReadTimeoutMs);
+                } catch (IOException e) {
+                    throw new ExecutionException(e);
+                } finally {
+                    if (con != null)
+                        con.disconnect();
+                }
+            });
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof IOException)
+                throw (IOException) e.getCause();
+            else
+                throw new KafkaException(e.getCause());
+        }
+
+        return parseAccessToken(responseBody);
+    }
+
+    protected static String post(HttpURLConnection con, Map<String, String> headers, String requestBody,
+                                 Integer connectTimeoutMs, Integer readTimeoutMs) throws IOException, UnretryableException {
+        handleInput(con, headers, requestBody, connectTimeoutMs, readTimeoutMs);
+        return handleOutput(con);
+    }
+
+    protected static void handleInput(HttpURLConnection con, Map<String, String> headers, String requestBody,
+                                      Integer connectTimeoutMs, Integer readTimeoutMs) throws IOException, UnretryableException {
+        log.debug("handleInput - starting post for {}", con.getURL());
+        con.setRequestMethod("POST");
+        con.setRequestProperty("Accept", "application/json");
+        con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+
+        if (headers != null) {
+            for (Map.Entry<String, String> header : headers.entrySet())
+                con.setRequestProperty(header.getKey(), header.getValue());
+        }
+
+        con.setRequestProperty("Cache-Control", "no-cache");
+
+        if (requestBody != null) {
+            con.setRequestProperty("Content-Length", String.valueOf(requestBody.length()));
+            con.setDoOutput(true);
+        }
+
+        con.setUseCaches(false);
+
+        if (connectTimeoutMs != null)
+            con.setConnectTimeout(connectTimeoutMs);
+
+        if (readTimeoutMs != null)
+            con.setReadTimeout(readTimeoutMs);
+
+        log.debug("handleInput - preparing to connect to {}", con.getURL());
+        con.connect();
+
+        if (requestBody != null) {
+            try (OutputStream os = con.getOutputStream()) {
+                ByteArrayInputStream is = new ByteArrayInputStream(requestBody.getBytes(StandardCharsets.UTF_8));
+                log.debug("handleInput - preparing to write request body to {}", con.getURL());
+                copy(is, os);
+            }
+        }
+    }
+
+    protected static String handleOutput(final HttpURLConnection con) throws IOException {
+        int responseCode = con.getResponseCode();
+        log.debug("handleOutput - responseCode: {}", responseCode);
+
+        String responseBody = null;
+
+        try (InputStream is = con.getInputStream()) {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            log.debug("handleOutput - preparing to read response body from {}", con.getURL());
+            copy(is, os);
+            responseBody = os.toString(StandardCharsets.UTF_8.name());
+        } catch (Exception e) {
+            log.warn("handleOutput - error retrieving data", e);
+        }
+
+        if (responseCode == HttpURLConnection.HTTP_OK || responseCode == HttpURLConnection.HTTP_CREATED) {
+            log.debug("handleOutput - responseCode: {}, response: {}", responseCode, responseBody);
+
+            if (responseBody == null || responseBody.isEmpty())
+                throw new IOException(String.format(
+                        "The token endpoint response was unexpectedly empty despite response code %s from %s",
+                        responseCode, con.getURL()));
+
+            return responseBody;
+        } else {
+            log.warn("handleOutput - error response code: {}, error response body: {}", responseCode, responseBody);
+
+            if (UNRETRYABLE_HTTP_CODES.contains(responseCode)) {
+                // We know that this is a non-transient error, so let's not keep retrying the
+                // request unnecessarily.
+                throw new UnretryableException(new IOException(String.format(
+                        "The response code %s was encountered reading the token endpoint response; will not attempt further retries",
+                        responseCode)));
+            } else {
+                // We don't know if this is a transient (retryable) error or not, so let's
+                // assume
+                // it is.
+                throw new IOException(String.format(
+                        "The unexpected response code %s was encountered reading the token endpoint response",
+                        responseCode));
+            }
+        }
+    }
+
+    static void copy(InputStream is, OutputStream os) throws IOException {
+        byte[] buf = new byte[4096];
+        int b;
+
+        while ((b = is.read(buf)) != -1)
+            os.write(buf, 0, b);
+    }
+
+    protected static String formatRequestBody(Map<String, String> grantExtensions) {
+        StringBuilder requestParameters = new StringBuilder();
+        for (Map.Entry<String, String> entry : grantExtensions.entrySet()) {
+            requestParameters.append("&").append(entry.getKey()).append("=").append(entry.getValue());
+        }
+        return requestParameters.toString();
+    }
+
+    protected static String parseAccessToken(String responseBody) throws IOException {
+        log.debug("parseAccessToken - responseBody: {}", responseBody);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode rootNode = mapper.readTree(responseBody);
+        JsonNode accessTokenNode = rootNode.at("/access_token");
+
+        if (accessTokenNode == null) {
+            // Only grab the first N characters so that if the response body is huge, we
+            // don't
+            // blow up.
+            String snippet = responseBody;
+
+            if (snippet.length() > MAX_RESPONSE_BODY_LENGTH) {
+                int actualLength = responseBody.length();
+                String s = responseBody.substring(0, MAX_RESPONSE_BODY_LENGTH);
+                snippet = String.format("%s (trimmed to first %s characters out of %s total)", s,
+                        MAX_RESPONSE_BODY_LENGTH, actualLength);
+            }
+
+            throw new IOException(String.format(
+                    "The token endpoint response did not contain an access_token value. Response: (%s)", snippet));
+        }
+
+        return sanitizeString("the token endpoint response's access_token JSON attribute", accessTokenNode.textValue());
+    }
+
+    private static String sanitizeString(String name, String value) {
+        if (value == null)
+            throw new IllegalArgumentException(String.format("The value for %s must be non-null", name));
+
+        if (value.isEmpty())
+            throw new IllegalArgumentException(String.format("The value for %s must be non-empty", name));
+
+        value = value.trim();
+
+        if (value.isEmpty())
+            throw new IllegalArgumentException(
+                    String.format("The value for %s must not contain only whitespace", name));
+
+        return value;
+    }
+
+}

--- a/modules/oauth-client/src/main/java/com/ibm/eventstreams_sdk/oauth/client/IAMTokenRetrieverFactory.java
+++ b/modules/oauth-client/src/main/java/com/ibm/eventstreams_sdk/oauth/client/IAMTokenRetrieverFactory.java
@@ -1,0 +1,82 @@
+// Copyright 2023 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.ibm.eventstreams_sdk.oauth.client;
+
+import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenRetriever;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URL;
+import java.util.Map;
+
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MAX_MS;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_READ_TIMEOUT_MS;
+
+abstract class IAMTokenRetrieverFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(IAMTokenRetrieverFactory.class);
+
+    public static final String IAM_TOKEN_ENDPOINT = "https://iam.cloud.ibm.com/identity/token";
+    public static final String GRANT_TYPE_CONFIG = "grant_type";
+    public static final String GRANT_TYPE_APIKEY = "urn:ibm:params:oauth:grant-type:apikey";
+    public static final String GRANT_EXT_APIKEY = "apikey";
+    public static final String GRANT_EXT_TOKEN = "access_token";
+    public static final String SASL_MECHANISM_OAUTH = "OAUTHBEARER";
+
+    public static AccessTokenRetriever create(
+            Map<String, ?> configs,
+            String saslMechanism,
+            Map<String, Object> jaasConfig) {
+        if (!SASL_MECHANISM_OAUTH.equals(saslMechanism)) {
+            throw new IllegalArgumentException(String.format("unsupported SASL_MECHANISM:'%s'", saslMechanism));
+        }
+        ConfigurationUtils cu = new ConfigurationUtils(configs, saslMechanism);
+        URL tokenEndpointUrl = null ;
+        try {
+            tokenEndpointUrl = cu.validateUrl(SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL);
+        } catch (Exception e) {
+            logger.warn("invalid " + SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL + " fall back to : " + IAM_TOKEN_ENDPOINT);
+            try {
+                tokenEndpointUrl = new URL(IAM_TOKEN_ENDPOINT);
+            } catch (Exception ee) {
+                // this should not happen
+            }
+        }
+
+        JaasOptionsUtils jou = new JaasOptionsUtils(jaasConfig);
+        String grantType = jou.validateString(GRANT_TYPE_CONFIG, true);
+        String apikey = jou.validateString(GRANT_EXT_APIKEY, true);
+
+        SSLSocketFactory sslSocketFactory = null;
+
+        if (jou.shouldCreateSSLSocketFactory(tokenEndpointUrl))
+            sslSocketFactory = jou.createSSLSocketFactory();
+
+        if (grantType.equals(GRANT_TYPE_APIKEY)) {
+            return new IAMAPIKeyTokenRetriever(grantType, apikey, tokenEndpointUrl.toString(), sslSocketFactory,
+                    cu.validateLong(SASL_LOGIN_RETRY_BACKOFF_MS), cu.validateLong(SASL_LOGIN_RETRY_BACKOFF_MAX_MS),
+                    cu.validateInteger(SASL_LOGIN_CONNECT_TIMEOUT_MS, false),
+                    cu.validateInteger(SASL_LOGIN_READ_TIMEOUT_MS, false));
+        } else {
+            throw new IllegalArgumentException(String.format("unsupported grant_type:'%s'", grantType));
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
 
         <module>modules/schemaregistry</module>
 
+        <module>modules/oauth-client</module>
+
         <!-- >>> Uncomment the following line if you want to build the examples -->
         <module>modules/examples</module>
     </modules>


### PR DESCRIPTION
This PR:

- Copies the oauth-client code from the https://github.com/IBM/eventstreams-samples repo
- Edits pom.xml of oauth-client to include the parent details
- Code changes to pass the checkstyle rules
- Upgrades the kafka client to 3.6.0