### PR TITLE
fix: config javadoc plugin to not fail on error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,6 +427,7 @@
           <footer>IBM Corporation</footer>
           <source>8</source>
           <detectJavaApiLink>false</detectJavaApiLink>
+          <failOnError>false</failOnError>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
The older oauth-client module has javadoc errors due to its importing of internal classes from Kafka client. 
This commit configures the maven javadoc plugin to not fail on error.

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->